### PR TITLE
Less shitty regex

### DIFF
--- a/gg.js
+++ b/gg.js
@@ -37,4 +37,3 @@ var result     = fetch(target).then(response => response.body).then(rb => {
   document.body.innerHTML = result.replaceAll(re, degoo);
   //document.body.innerHTML = newresult; // accidentally discards some parts of the dom that we want to keep ;-; fix next time
 });
-

--- a/gg.js
+++ b/gg.js
@@ -3,13 +3,13 @@ function degoo(match, p1, p2, p3, offset, string) {
 }
 
 const test    = /Please click <a href="(\/search\?.+?(?=">here<\/a>))">here<\/a> if you/g;
-const link    = document.body.textContent.match(test);
-const target  = new Request("https://www.google.com" + link);
-const re      = /(<a href=")(?:\/url\?)(?!q=(?:http.+?(?=&amp;(?:sa|ved|usg)=)))?(?:q=)(http.+?(?=&amp;(?:sa|ved|usg)=))(?:&amp;(?:sa|ved|usg)=.+?(?="><))("><)/g;
+const link    = [...document.body.textContent.matchAll(test)];
+const target  = new Request("https://www.google.com" + link[0][1]);
 
-// replace with $1$2$3
-
-
+// OG fix
+const re      = /(<a href=")(?:\/url\?)(?!q=(?:http.+?(?=&amp;(?:sa|ved|usg)=)))?(?:q=)(http.+?(?=&amp;(?:sa|ved|usg)=))(?:&amp;(?:sa|ved|usg)=(?:\\"|[^"])+?(?="><))("><)/g;
+// new fix
+const re2 = / ?(?:data-ved|onmousedown)="[^"]+?" ?/gi;
 
 // thank u mozilla.org
 var result     = fetch(target).then(response => response.body).then(rb => {
@@ -34,6 +34,7 @@ var result     = fetch(target).then(response => response.body).then(rb => {
   return new Response(stream, { headers: { "Content-Type": "text/html" } }).text();
 })
 .then(result => {
-  document.body.innerHTML = result.replaceAll(re, degoo);
-  //document.body.innerHTML = newresult; // accidentally discards some parts of the dom that we want to keep ;-; fix next time
+  let newresult = result.replaceAll(re, degoo);
+  let newnewresult = newresult.replaceAll(re2, '');
+  document.body.innerHTML = newnewresult;
 });

--- a/gg.js
+++ b/gg.js
@@ -1,5 +1,5 @@
-function degoo(match, p1, p2, p3, p4, p5, offset, string) {
-  return p1 + decodeURIComponent(p3).replaceAll(' ', '+') + p5;
+function degoo(match, p1, p2, p3, offset, string) {
+  return p1 + decodeURIComponent(p2).replaceAll(' ', '+') + p3;
 }
 
 const test    = /Please click <a href="(\/search\?.+?(?=">here<\/a>))">here<\/a> if you/g;
@@ -7,7 +7,12 @@ const str     = document.body.textContent;
 const array   = [...str.matchAll(test)];
 const cleaned = array[0][1].replaceAll('&amp;', '&');
 const target  = new Request("https://www.google.com" + cleaned);
-const re      = /(<a href=")(\/url\?q=)(http.+?(?=&amp;(?:sa|ved|usg)=))(&amp;(?:sa|ved|usg)=.+?(?="><[spandiv]{3,4}))("><[spandiv]{3,4} class="[A-Za-z\d ]+">.*?(?=<[spandiv]{3,4}))/g;
+
+const re      = /(<a href=")(?:\/url\?)(?!q=(?:http.+?(?=&amp;(?:sa|ved|usg)=)))?(?:q=)(http.+?(?=&amp;(?:sa|ved|usg)=))(?:&amp;(?:sa|ved|usg)=.+?(?="><))("><)/g;
+
+// replace with $1$2$3
+
+
 
 // thank u mozilla.org
 var result     = fetch(target).then(response => response.body).then(rb => {

--- a/gg.js
+++ b/gg.js
@@ -3,11 +3,8 @@ function degoo(match, p1, p2, p3, offset, string) {
 }
 
 const test    = /Please click <a href="(\/search\?.+?(?=">here<\/a>))">here<\/a> if you/g;
-const str     = document.body.textContent;
-const array   = [...str.matchAll(test)];
-const cleaned = array[0][1].replaceAll('&amp;', '&');
-const target  = new Request("https://www.google.com" + cleaned);
-
+const link    = document.body.textContent.match(test);
+const target  = new Request("https://www.google.com" + link);
 const re      = /(<a href=")(?:\/url\?)(?!q=(?:http.+?(?=&amp;(?:sa|ved|usg)=)))?(?:q=)(http.+?(?=&amp;(?:sa|ved|usg)=))(?:&amp;(?:sa|ved|usg)=.+?(?="><))("><)/g;
 
 // replace with $1$2$3
@@ -37,6 +34,8 @@ var result     = fetch(target).then(response => response.body).then(rb => {
   return new Response(stream, { headers: { "Content-Type": "text/html" } }).text();
 })
 .then(result => {
-  let newresult = result.replaceAll(re, degoo);
-  document.body.innerHTML = newresult; // accidentally discards some parts of the dom that we want to keep ;-; fix next time
+  document.body.innerHTML = result.replaceAll(re, degoo);
+  //document.body.innerHTML = newresult; // accidentally discards some parts of the dom that we want to keep ;-; fix next time
 });
+
+console.log("hi");

--- a/gg.js
+++ b/gg.js
@@ -38,4 +38,3 @@ var result     = fetch(target).then(response => response.body).then(rb => {
   //document.body.innerHTML = newresult; // accidentally discards some parts of the dom that we want to keep ;-; fix next time
 });
 
-console.log("hi");


### PR DESCRIPTION
add a new workaround for some html black magic that was going on

seems like the `/url?` links are being constructed differently, not sure if something changed on google's end or if I am being served a different version of the web app than i was before. it seems like there isn't ever just one definitive thing going on over there

I might have broken the old fix while figuring this out, if `main` still works for you and this one doesn't then pls use that

i left the possibly broken original fix in this pr to mess around with later